### PR TITLE
WIP: Pack Newline Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 vendor
 
 .DS_Store
+configimporter
+osx-attacks.conf

--- a/config_builder.go
+++ b/config_builder.go
@@ -86,7 +86,11 @@ func collectExternalPacks(buffer []byte, rdr externalReader) (*importBody, error
 }
 
 func decodeConfig(buff []byte) (*osqueryConfig, error) {
+	buff = bytes.Replace(buff, []byte(" \\\n"), []byte(""), -1)
+	buff = bytes.Replace(buff, []byte("        "), []byte(" "), -1)
+
 	reader := bytes.NewReader(buff)
+
 	var cfg osqueryConfig
 	err := json.NewDecoder(reader).Decode(&cfg)
 	if err != nil {


### PR DESCRIPTION
So pulling packs in from other sources it's common to have newlines in the query portion for readability such as: 

```
{
  "platform": "darwin",
  "queries": {
    "WireLurker": {
      "query" : "select * from launchd where \
        name = 'com.apple.machook_damon.plist' OR \
        name = 'com.apple.globalupdate.plist' OR \
        name = 'com.apple.appstore.plughelper.plist' OR \
        name = 'com.apple.MailServiceAgentHelper.plist' OR \
        name = 'com.apple.systemkeychain-helper.plist' OR \
        name = 'com.apple.periodic-dd-mm-yy.plist';",
      "interval" : "3600",
      "version": "1.4.5",
      "description" : "(https://github.com/PaloAltoNetworks-BD/WireLurkerDetector)",
      "value" : "Artifact used by this malware"
    }
}
```

`configimporter` doesn't like this very much (understandably) and threw an error. So this adds some code to remove newlines and whitespace in `decodeConfig`:

```
buff = bytes.Replace(buff, []byte(" \\\n"), []byte(""), -1)
buff = bytes.Replace(buff, []byte("        "), []byte(" "), -1)
```

This works, and I verified it does create a non-newline version, but the import overall is still failing silently. The dry-run succeeds and the login in and all works, but it's not successfully importing rules. 

I'm still debugging that aspect, but wanted to kick this off for discussion. Fixes #4 

